### PR TITLE
fix: allow ng-simple-state 22 in the optional peer range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "globals": "^17.6.0",
         "jsdom": "^29.1.1",
         "ng-packagr": "^22.0.0",
-        "ng-simple-state": "^21.1.5",
+        "ng-simple-state": "^22.1.0",
         "prettier": "^3.9.5",
         "typescript": "^6.0.3",
         "vitest": "^4.0.8"
@@ -47,7 +47,7 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "ng-simple-state": "^21.1.4"
+        "ng-simple-state": ">=21.1.4"
       },
       "peerDependenciesMeta": {
         "ng-simple-state": {
@@ -8744,17 +8744,17 @@
       }
     },
     "node_modules/ng-simple-state": {
-      "version": "21.1.5",
-      "resolved": "https://registry.npmjs.org/ng-simple-state/-/ng-simple-state-21.1.5.tgz",
-      "integrity": "sha512-tx1ckGOCb8XTyFnWrwmYojDIJhNhTrDP/qpddSP3oow/NcV56Ns5BrJJt2/CEfm3Lh0Fw6Wvzu/Pn+o0ZGBc3w==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/ng-simple-state/-/ng-simple-state-22.1.0.tgz",
+      "integrity": "sha512-3R0+yDewIIfZitsCqr4nd8vFCpaBZCp6RbmP1hPvEGMIUzrSV1vmdQ+6gxdbSJc/uEZKzyo50XpfE9cN+Wcu5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/common": ">15.0.0",
-        "@angular/core": ">15.0.0"
+        "@angular/common": ">=22.0.0",
+        "@angular/core": ">=22.0.0"
       }
     },
     "node_modules/node-addon-api": {
@@ -16742,9 +16742,9 @@
       }
     },
     "ng-simple-state": {
-      "version": "21.1.5",
-      "resolved": "https://registry.npmjs.org/ng-simple-state/-/ng-simple-state-21.1.5.tgz",
-      "integrity": "sha512-tx1ckGOCb8XTyFnWrwmYojDIJhNhTrDP/qpddSP3oow/NcV56Ns5BrJJt2/CEfm3Lh0Fw6Wvzu/Pn+o0ZGBc3w==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/ng-simple-state/-/ng-simple-state-22.1.0.tgz",
+      "integrity": "sha512-3R0+yDewIIfZitsCqr4nd8vFCpaBZCp6RbmP1hPvEGMIUzrSV1vmdQ+6gxdbSJc/uEZKzyo50XpfE9cN+Wcu5Q==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "tslib": "^2.8.1"
   },
   "peerDependencies": {
-    "ng-simple-state": "^21.1.4"
+    "ng-simple-state": ">=21.1.4"
   },
   "peerDependenciesMeta": {
     "ng-simple-state": {
@@ -75,7 +75,7 @@
     "globals": "^17.6.0",
     "jsdom": "^29.1.1",
     "ng-packagr": "^22.0.0",
-    "ng-simple-state": "^21.1.5",
+    "ng-simple-state": "^22.1.0",
     "prettier": "^3.9.5",
     "typescript": "^6.0.3",
     "vitest": "^4.0.8"

--- a/projects/ng-http-caching/package.json
+++ b/projects/ng-http-caching/package.json
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "@angular/common": ">15.0.0",
     "@angular/core": ">15.0.0",
-    "ng-simple-state": "^21.1.4"
+    "ng-simple-state": ">=21.1.4"
   },
   "peerDependenciesMeta": {
     "ng-simple-state": {


### PR DESCRIPTION
You asked me to check whether the other two libraries had the same wrong peer range as `ng-as` and `ng-generic-pipe`. Short answer: **they did not** — but this repo has a different, real one.

## What was NOT wrong

- `@angular/core: ">15.0.0"` is **correct here**. Unlike `ng-as`/`ng-generic-pipe`, this library has no components and no `@Input({ required: true })`. The most recent API it uses is `makeEnvironmentProviders` (Angular 15.0), so 15.0.1+ genuinely works.
- The `@angular/common` peer is **legitimate here** too — the library imports from `@angular/common/http`.
- `ng-simple-state` declares `>=22.0.0` for Angular and needed no change at all.

## What was wrong

The adapter declared `ng-simple-state: "^21.1.4"`, but ng-simple-state has been at 22.x for a while and its own peers now require Angular >= 22. So anyone on a current Angular who uses the adapter hits a peer conflict on install: the caret pins the range to the 21 major.

`peerDependenciesMeta.optional` does not save it — that only stops npm complaining when the package is **absent**. Present and out of range still conflicts.

## The fix

The range becomes `>=21.1.4`, which matches how the Angular peers are already declared in this repo and avoids a bump on every major of a library whose major just tracks Angular's.

The dev dependency moves from `^21.1.5` to `^22.1.0`, so CI exercises the pairing users actually get — previously it only ever tested against 21.

## Verified

Installed ng-simple-state 22.1.0 and ran the real thing: 214 tests pass, both entry points build (`ng-http-caching` and `ng-http-caching/ng-simple-state`), lint and format clean.